### PR TITLE
Parser: easy generic modules as service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **DS_Store
 .gitignore~
+.java-version
 /target
 *.iml

--- a/src/main/java/com/noleme/vault/container/definition/ServiceValue.java
+++ b/src/main/java/com/noleme/vault/container/definition/ServiceValue.java
@@ -1,0 +1,21 @@
+package com.noleme.vault.container.definition;
+
+/**
+ * @author Pierre Lecerf (pierre@noleme.com)
+ * Created on 15/08/2021
+ */
+public class ServiceValue <T> extends ServiceDefinition
+{
+    private final T value;
+
+    public ServiceValue(String identifier, T value)
+    {
+        this.identifier = identifier;
+        this.value = value;
+    }
+
+    public T getValue()
+    {
+        return this.value;
+    }
+}

--- a/src/main/java/com/noleme/vault/factory/VaultFactory.java
+++ b/src/main/java/com/noleme/vault/factory/VaultFactory.java
@@ -306,6 +306,8 @@ public class VaultFactory
             {
                 if (def instanceof ServiceAlias)
                     cellar.putService(def.getIdentifier(), cellar.getService(((ServiceAlias)def).getTarget().getIdentifier()));
+                else if (def instanceof ServiceValue<?>)
+                    cellar.putService(def.getIdentifier(), ((ServiceValue<?>) def).getValue());
                 else if (def instanceof ServiceInstantiation)
                 {
                     Object instance = this.makeInstantiation((ServiceInstantiation)def, cellar);

--- a/src/main/java/com/noleme/vault/parser/module/GenericModule.java
+++ b/src/main/java/com/noleme/vault/parser/module/GenericModule.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.noleme.json.Json;
 import com.noleme.json.JsonException;
+import com.noleme.vault.container.definition.ServiceProvider;
+import com.noleme.vault.container.definition.ServiceValue;
 import com.noleme.vault.container.register.Definitions;
 import com.noleme.vault.exception.VaultParserException;
 
@@ -23,15 +25,31 @@ public class GenericModule<T> implements VaultModule
     ;
 
     /**
+     * Creates a ${GenericModule} which will attempt to map a given node to an instance of the provided type.
+     * The processor instance will be able to manipulate the resulting instance and perform changes over the ${Definitions} instance.
      *
-     * @param identifier
-     * @param type
+     * @param identifier the identifier for the module, ie the root-level key in the json object
+     * @param type the target type for deserialization
+     * @param processor the processor responsible for handling the resulting deserialized instance
      */
     public GenericModule(String identifier, Class<T> type, Processor<T> processor)
     {
         this.identifier = identifier;
         this.type = type;
         this.processor = processor;
+    }
+
+    /**
+     * Creates a ${GenericModule} which will attempt to map a given node to an instance of the provided type.
+     * This constructor will use a default ${Processor} which will simply register the resulting instance as a service.
+     *
+     * @param identifier the identifier for the module, ie the root-level key in the json object
+     * @param type the target type for deserialization
+     * @param name the name of the service associated to the resulting deserialized instance
+     */
+    public GenericModule(String identifier, Class<T> type, String name)
+    {
+        this(identifier, type, (cfg, defs) -> defs.services().set(name, new ServiceValue<>(name, cfg)));
     }
 
     @Override

--- a/src/test/java/com/noleme/vault/parser/ModuleTest.java
+++ b/src/test/java/com/noleme/vault/parser/ModuleTest.java
@@ -64,6 +64,18 @@ public class ModuleTest
         makeAssertions(cellar);
     }
 
+    @Test
+    void genericDirectAccessTest() throws VaultInjectionException
+    {
+        VaultParser parser = new VaultCompositeParser().register(new GenericModule<>("custom", TestConfig.class, "custom_config"));
+        var cellar = new VaultFactory(parser).populate(new Cellar(), "com/noleme/vault/parser/module/module.yml");
+
+        var config = cellar.getService("custom_config", TestConfig.class);
+
+        Assertions.assertEquals("this_is_my_new_string", config.value);
+        Assertions.assertIterableEquals(List.of("my_provider.a", "my_provider.b", "my_provider.c"), config.providers);
+    }
+
     public static class TestModule implements VaultModule
     {
         @Override


### PR DESCRIPTION
Adds an easy way to create `GenericModule` modules with a direct registration of the resulting instance.

Eg. given the following `custom.yml` file:

```yml
custom:
  some_integer: 123
  some_string: "abcd"
```

and the following configuration type:

```java
class MyCustomConfig
{
  public int someInteger;
  public String someString;
}
```

it is now possible to do the following:

```java
VaultFactory.defaultParser.register(new GenericModule<>("custom", MyCustomConfig.class, "custom_config"));
var vault = Vault.with("custom.yml");
```

and then:

```java
MyCustomConfig config = vault.instance(MyCustomConfig.class);
```

..or just inject it in another class, `custom_config` here being the optional `@Named` value.