### PR TITLE
Parser: differentiated VaultAdjuster functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.noleme</groupId>
     <artifactId>noleme-vault</artifactId>
-    <version>0.17.2</version>
+    <version>0.18</version>
     <packaging>jar</packaging>
 
     <name>Noleme Vault</name>

--- a/src/main/java/com/noleme/vault/builder/CellarPathStage.java
+++ b/src/main/java/com/noleme/vault/builder/CellarPathStage.java
@@ -35,7 +35,7 @@ public class CellarPathStage implements BuildStage
      */
     public CellarPathStage(VaultFactory factory, String path)
     {
-        this(factory, path, defs -> {});
+        this(factory, path, VaultAdjuster.noop());
     }
 
     /**
@@ -55,7 +55,7 @@ public class CellarPathStage implements BuildStage
      */
     public CellarPathStage(VaultFactory factory, List<String> paths)
     {
-        this(factory, paths, defs -> {});
+        this(factory, paths, VaultAdjuster.noop());
     }
 
     /**

--- a/src/main/java/com/noleme/vault/parser/VaultParser.java
+++ b/src/main/java/com/noleme/vault/parser/VaultParser.java
@@ -7,7 +7,6 @@ import com.noleme.vault.parser.module.VaultModule;
 import com.noleme.vault.parser.preprocessor.VaultPreprocessor;
 import com.noleme.vault.parser.resolver.source.Source;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -19,33 +18,23 @@ public interface VaultParser
 {
     default Definitions extract(Source source) throws VaultParserException
     {
-        return this.extract(source, new Definitions(), Collections.emptyList());
+        return this.extract(source, new Definitions(), VaultAdjuster.noop());
     }
 
-    default Definitions extract(Source source, Definitions definitions, VaultAdjuster... adjusters) throws VaultParserException
+    default Definitions extract(Source source, Definitions definitions, VaultAdjuster adjuster) throws VaultParserException
     {
-        return this.extract(source, definitions, Arrays.asList(adjusters));
-    }
-
-    default Definitions extract(Source source, Definitions definitions, Collection<VaultAdjuster> adjusters) throws VaultParserException
-    {
-        return this.extract(Collections.singletonList(source), definitions, adjusters);
-    }
-
-    default Definitions extract(Collection<Source> sources, Definitions definitions, VaultAdjuster... adjusters) throws VaultParserException
-    {
-        return this.extract(sources, definitions, Arrays.asList(adjusters));
+        return this.extract(Collections.singletonList(source), definitions, adjuster);
     }
 
     /**
      *
      * @param sources
      * @param definitions
-     * @param adjusters
+     * @param adjuster
      * @return
      * @throws VaultParserException
      */
-    Definitions extract(Collection<Source> sources, Definitions definitions, Collection<VaultAdjuster> adjusters) throws VaultParserException;
+    Definitions extract(Collection<Source> sources, Definitions definitions, VaultAdjuster adjuster) throws VaultParserException;
 
     default Definitions extract(String origin) throws VaultParserException
     {
@@ -54,33 +43,28 @@ public interface VaultParser
 
     default Definitions extract(String origin, Definitions definitions) throws VaultParserException
     {
-        return this.extract(origin, definitions, Collections.emptyList());
+        return this.extract(origin, definitions, VaultAdjuster.noop());
     }
 
-    default Definitions extract(String origin, Definitions definitions, VaultAdjuster... adjusters) throws VaultParserException
+    default Definitions extract(String origin, Definitions definitions, VaultAdjuster adjuster) throws VaultParserException
     {
-        return this.extract(origin, definitions, Arrays.asList(adjusters));
+        return this.extractOrigin(Collections.singletonList(origin), definitions, adjuster);
     }
 
-    default Definitions extract(String origin, Definitions definitions, Collection<VaultAdjuster> adjusters) throws VaultParserException
+    default Definitions extractOrigin(Collection<String> origins, Definitions definitions) throws VaultParserException
     {
-        return this.extractOrigin(Collections.singletonList(origin), definitions, adjusters);
-    }
-
-    default Definitions extractOrigin(Collection<String> origins, Definitions definitions, VaultAdjuster... adjusters) throws VaultParserException
-    {
-        return this.extractOrigin(origins, definitions, Arrays.asList(adjusters));
+        return this.extractOrigin(origins, definitions, VaultAdjuster.noop());
     }
 
     /**
      *
      * @param origins
      * @param definitions
-     * @param adjusters
+     * @param adjuster
      * @return
      * @throws VaultParserException
      */
-    Definitions extractOrigin(Collection<String> origins, Definitions definitions, Collection<VaultAdjuster> adjusters) throws VaultParserException;
+    Definitions extractOrigin(Collection<String> origins, Definitions definitions, VaultAdjuster adjuster) throws VaultParserException;
 
     /**
      * Register a custom preprocessor for performing modifications over configuration nodes before compilation passes.

--- a/src/main/java/com/noleme/vault/parser/adjuster/Adjuster.java
+++ b/src/main/java/com/noleme/vault/parser/adjuster/Adjuster.java
@@ -1,0 +1,12 @@
+package com.noleme.vault.parser.adjuster;
+
+import com.noleme.vault.exception.VaultParserException;
+
+/**
+ * @author Pierre LECERF (pierre@noleme.com)
+ * Created on 03/12/2022
+ */
+public interface Adjuster<T>
+{
+    void adjust(T input) throws VaultParserException;
+}

--- a/src/main/java/com/noleme/vault/parser/adjuster/ScopeAdjuster.java
+++ b/src/main/java/com/noleme/vault/parser/adjuster/ScopeAdjuster.java
@@ -1,0 +1,9 @@
+package com.noleme.vault.parser.adjuster;
+
+import com.noleme.vault.container.register.index.Scopes;
+
+/**
+ * @author Pierre LECERF (pierre@noleme.com)
+ * Created on 03/12/2022
+ */
+public interface ScopeAdjuster extends Adjuster<Scopes> {}

--- a/src/main/java/com/noleme/vault/parser/adjuster/ServiceAdjuster.java
+++ b/src/main/java/com/noleme/vault/parser/adjuster/ServiceAdjuster.java
@@ -1,0 +1,9 @@
+package com.noleme.vault.parser.adjuster;
+
+import com.noleme.vault.container.register.index.Services;
+
+/**
+ * @author Pierre LECERF (pierre@noleme.com)
+ * Created on 03/12/2022
+ */
+public interface ServiceAdjuster extends Adjuster<Services> {}

--- a/src/main/java/com/noleme/vault/parser/adjuster/TagAdjuster.java
+++ b/src/main/java/com/noleme/vault/parser/adjuster/TagAdjuster.java
@@ -1,0 +1,9 @@
+package com.noleme.vault.parser.adjuster;
+
+import com.noleme.vault.container.register.index.Tags;
+
+/**
+ * @author Pierre LECERF (pierre@noleme.com)
+ * Created on 03/12/2022
+ */
+public interface TagAdjuster extends Adjuster<Tags> {}

--- a/src/main/java/com/noleme/vault/parser/adjuster/VariableAdjuster.java
+++ b/src/main/java/com/noleme/vault/parser/adjuster/VariableAdjuster.java
@@ -1,0 +1,9 @@
+package com.noleme.vault.parser.adjuster;
+
+import com.noleme.vault.container.register.index.Variables;
+
+/**
+ * @author Pierre LECERF (pierre@noleme.com)
+ * Created on 03/12/2022
+ */
+public interface VariableAdjuster extends Adjuster<Variables> {}

--- a/src/main/java/com/noleme/vault/parser/adjuster/VaultAdjuster.java
+++ b/src/main/java/com/noleme/vault/parser/adjuster/VaultAdjuster.java
@@ -1,18 +1,171 @@
 package com.noleme.vault.parser.adjuster;
 
 import com.noleme.vault.container.register.Definitions;
+import com.noleme.vault.container.register.index.Scopes;
+import com.noleme.vault.container.register.index.Services;
+import com.noleme.vault.container.register.index.Tags;
+import com.noleme.vault.container.register.index.Variables;
 import com.noleme.vault.exception.VaultParserException;
+import com.noleme.vault.parser.module.VaultModule;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 
 /**
  * @author Pierre Lecerf (plecerf@lumiomedical.com)
  * Created on 2020/11/28
  */
-public interface VaultAdjuster
+public final class VaultAdjuster
 {
-    /**
-     *
-     * @param definitions
-     * @throws VaultParserException
-     */
-    void adjust(Definitions definitions) throws VaultParserException;
+    private final ScopeAdjuster scope;
+    private final ServiceAdjuster service;
+    private final TagAdjuster tag;
+    private final VariableAdjuster variable;
+
+    private static final VaultAdjuster NO_OP = VaultAdjuster.adjuster().build();
+
+    VaultAdjuster(
+        ScopeAdjuster scope,
+        ServiceAdjuster service,
+        TagAdjuster tag,
+        VariableAdjuster variable
+    ) {
+        this.scope = scope;
+        this.service = service;
+        this.tag = tag;
+        this.variable = variable;
+    }
+
+    public static VaultAdjuster noop()
+    {
+        return NO_OP;
+    }
+
+    public static VaultAdjusterBuilder adjuster()
+    {
+        return new VaultAdjusterBuilder();
+    }
+
+    public static VaultAdjuster scopes(ScopeAdjuster adjuster)
+    {
+        return new VaultAdjusterBuilder().scopes(adjuster).build();
+    }
+
+    public static VaultAdjuster services(ServiceAdjuster adjuster)
+    {
+        return new VaultAdjusterBuilder().services(adjuster).build();
+    }
+
+    public static VaultAdjuster tags(TagAdjuster adjuster)
+    {
+        return new VaultAdjusterBuilder().tags(adjuster).build();
+    }
+
+    public static VaultAdjuster variables(VariableAdjuster adjuster)
+    {
+        return new VaultAdjusterBuilder().variables(adjuster).build();
+    }
+
+    public void adjust(Scopes scopes) throws VaultParserException
+    {
+        this.scope.adjust(scopes);
+    }
+
+    public void adjust(Services services) throws VaultParserException
+    {
+        this.service.adjust(services);
+    }
+
+    public void adjust(Tags tags) throws VaultParserException
+    {
+        this.tag.adjust(tags);
+    }
+
+    public void adjust(Variables variables) throws VaultParserException
+    {
+        this.variable.adjust(variables);
+    }
+
+    public static class VaultAdjusterBuilder
+    {
+        private ScopeAdjuster scope = scopes -> {};
+        private ServiceAdjuster service = services -> {};
+        private TagAdjuster tag = tags -> {};
+        private VariableAdjuster variable = variables -> {};
+
+        private VaultAdjusterBuilder() {}
+
+        public VaultAdjuster build()
+        {
+            return new VaultAdjuster(this.scope, this.service, this.tag, this.variable);
+        }
+
+        public VaultAdjusterBuilder scopes(ScopeAdjuster adjuster)
+        {
+            this.scope = adjuster;
+            return this;
+        }
+
+        public VaultAdjusterBuilder services(ServiceAdjuster adjuster)
+        {
+            this.service = adjuster;
+            return this;
+        }
+
+        public VaultAdjusterBuilder tags(TagAdjuster adjuster)
+        {
+            this.tag = adjuster;
+            return this;
+        }
+
+        public VaultAdjusterBuilder variables(VariableAdjuster adjuster)
+        {
+            this.variable = adjuster;
+            return this;
+        }
+    }
+
+    public static class VaultAdjusterMapper
+    {
+        private final Map<Class<? extends VaultModule>, VaultAdjusterAccessor<?>> adjusters;
+
+        public VaultAdjusterMapper()
+        {
+            this.adjusters = new HashMap<>();
+        }
+
+        public boolean knows(VaultModule module)
+        {
+            return this.adjusters.containsKey(module.getClass());
+        }
+
+        public VaultAdjusterAccessor<?> get(VaultModule module)
+        {
+            return this.adjusters.get(module.getClass());
+        }
+
+        public VaultAdjusterMapper register(Class<? extends VaultModule> moduleType, VaultAdjusterAccessor<?> accessorFunction)
+        {
+            this.adjusters.put(moduleType, accessorFunction);
+            return this;
+        }
+    }
+
+    public static class VaultAdjusterAccessor<T>
+    {
+        private final Function<Definitions, T> definitionsAccessor;
+        private final Function<VaultAdjuster, Adjuster<T>> adjusterAccessor;
+
+        public VaultAdjusterAccessor(Function<Definitions, T> definitionsAccessor, Function<VaultAdjuster, Adjuster<T>> adjusterAccessor)
+        {
+            this.definitionsAccessor = definitionsAccessor;
+            this.adjusterAccessor = adjusterAccessor;
+        }
+
+        public void adjust(VaultAdjuster adjuster, Definitions defs) throws VaultParserException
+        {
+            this.adjusterAccessor.apply(adjuster).adjust(this.definitionsAccessor.apply(defs));
+        }
+    }
 }

--- a/src/main/java/com/noleme/vault/parser/module/scope/ScopeModule.java
+++ b/src/main/java/com/noleme/vault/parser/module/scope/ScopeModule.java
@@ -80,6 +80,7 @@ public class ScopeModule implements VaultModule
         return new VaultCompositeParser(
             new FlexibleResolver(),
             Lists.of(
+                new VariableRegistrationModule(),
                 new ScopeVariableModule(json),
                 new VariableResolvingModule(),
                 new VariableReplacementModule(),

--- a/src/test/java/com/noleme/vault/factory/VariableMapTest.java
+++ b/src/test/java/com/noleme/vault/factory/VariableMapTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import static com.noleme.vault.factory.EnvTest.clearEnv;
 import static com.noleme.vault.factory.EnvTest.setEnv;
+import static com.noleme.vault.parser.adjuster.VaultAdjuster.variables;
 
 /**
  * @author Pierre LECERF (pierre@noleme.com)
@@ -30,39 +31,34 @@ public class VariableMapTest
     @Test
     void mapVariableTest()
     {
-        Assertions.assertDoesNotThrow(() -> {
-            setEnv("MY_VAR", "my_value");
+        setEnv("MY_VAR", "my_value");
 
-            var cellar = factory.populate(new Cellar(), "com/noleme/vault/parser/variable/map_variable.yml");
+        Cellar cellar = Assertions.assertDoesNotThrow(() -> factory.populate(new Cellar(), "com/noleme/vault/parser/variable/map_variable.yml"));
 
-            Assertions.assertTrue(cellar.hasVariable("my_map"));
-            Assertions.assertTrue(cellar.getVariable("my_map") instanceof Map);
-            Assertions.assertEquals(6, cellar.getVariable("my_map", Map.class).size());
+        Assertions.assertTrue(cellar.hasVariable("my_map"));
+        Assertions.assertTrue(cellar.getVariable("my_map") instanceof Map);
+        Assertions.assertEquals(6, cellar.getVariable("my_map", Map.class).size());
 
-            @SuppressWarnings("unchecked")
-            var map = (Map<String, Object>) cellar.getVariable("my_map", Map.class);
+        @SuppressWarnings("unchecked")
+        var map = (Map<String, Object>) cellar.getVariable("my_map", Map.class);
 
-            Assertions.assertEquals("something", map.get("my_string"));
-            Assertions.assertEquals(2345, map.get("my_integer"));
-            Assertions.assertEquals(12.34, map.get("my_double"));
-            Assertions.assertEquals(false, map.get("my_boolean"));
-            Assertions.assertEquals("abcde", map.get("my_ref"));
-            Assertions.assertEquals("my_value", map.get("my_env"));
-        });
+        Assertions.assertEquals("something", map.get("my_string"));
+        Assertions.assertEquals(2345, map.get("my_integer"));
+        Assertions.assertEquals(12.34, map.get("my_double"));
+        Assertions.assertEquals(false, map.get("my_boolean"));
+        Assertions.assertEquals("abcde", map.get("my_ref"));
+        Assertions.assertEquals("my_value", map.get("my_env"));
     }
 
     @Test
     void mapVariableTest__invalidDeclaration()
     {
-        Assertions.assertThrows(VaultInjectionException.class, () -> {
-            try {
-                factory.populate(new Cellar(), "com/noleme/vault/parser/variable/map_variable.invalid_declaration.yml");
-            }
-            catch (VaultInjectionException e) {
-                Assertions.assertTrue(e.getCause() instanceof VaultParserException);
-                throw e;
-            }
-        });
+        VaultInjectionException ex = Assertions.assertThrows(VaultInjectionException.class, () -> factory.populate(
+            new Cellar(),
+            "com/noleme/vault/parser/variable/map_variable.invalid_declaration.yml"
+        ));
+
+        Assertions.assertTrue(ex.getCause() instanceof VaultParserException);
     }
 
     @Test
@@ -71,7 +67,7 @@ public class VariableMapTest
         setEnv("MY_VAR", "my_value");
 
         Assertions.assertDoesNotThrow(() -> Vault.with(
-            defs -> defs.variables().set("provider.map.value", defs.variables().get("my_map")),
+            variables(vars -> vars.set("provider.map.value", vars.get("my_map"))),
             "com/noleme/vault/parser/variable/map_variable.yml",
             "com/noleme/vault/parser/provider/provider.map.yml"
         ));
@@ -83,7 +79,7 @@ public class VariableMapTest
         setEnv("MY_VAR", "my_value");
 
         Assertions.assertThrows(VaultInjectionException.class, () -> Vault.with(
-            defs -> defs.variables().set("provider.map.value", defs.variables().get("my_map")),
+            variables(vars -> vars.set("provider.map.value", vars.get("my_map"))),
             "com/noleme/vault/parser/variable/map_variable.yml",
             "com/noleme/vault/parser/provider/provider.map.invalid_reference.yml"
         ));
@@ -92,10 +88,8 @@ public class VariableMapTest
     @Test
     void mapVariableTest__emptyMap()
     {
-        Assertions.assertDoesNotThrow(() -> {
-            var cellar = Vault.with("com/noleme/vault/parser/provider/provider.map.yml").instance(Cellar.class);
+        Cellar cellar = Assertions.assertDoesNotThrow(() -> Vault.with("com/noleme/vault/parser/provider/provider.map.yml").instance(Cellar.class));
 
-            Assertions.assertEquals(0, cellar.getVariable("provider.map.value", Map.class).size());
-        });
+        Assertions.assertEquals(0, cellar.getVariable("provider.map.value", Map.class).size());
     }
 }

--- a/src/test/java/com/noleme/vault/parser/AdjusterTest.java
+++ b/src/test/java/com/noleme/vault/parser/AdjusterTest.java
@@ -5,17 +5,22 @@ import com.noleme.vault.container.definition.ServiceProvider;
 import com.noleme.vault.container.definition.ServiceValue;
 import com.noleme.vault.container.register.Definitions;
 import com.noleme.vault.exception.VaultException;
+import com.noleme.vault.exception.VaultInjectionException;
 import com.noleme.vault.exception.VaultParserException;
+import com.noleme.vault.service.BooleanProvider;
 import com.noleme.vault.service.tag.ComponentService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static com.noleme.vault.parser.adjuster.VaultAdjuster.*;
+
 /**
  * @author Pierre Lecerf (plecerf@lumiomedical.com)
  * Created on 2020/11/28
  */
+@SuppressWarnings("resource")
 public class AdjusterTest
 {
     @Test
@@ -24,9 +29,11 @@ public class AdjusterTest
         var parser = new VaultCompositeParser();
         int value = 1234;
 
-        Definitions def = parser.extract("com/noleme/vault/parser/simple.json", new Definitions(), defs -> {
-            defs.variables().set("my_variable", value);
-        });
+        Definitions def = parser.extract(
+            "com/noleme/vault/parser/simple.json",
+            new Definitions(),
+            variables(vars -> vars.set("my_variable", value))
+        );
 
         Assertions.assertEquals(value, def.variables().get("my_variable"));
     }
@@ -36,10 +43,13 @@ public class AdjusterTest
     {
         var component = new ComponentService("adjusted");
 
-        var vault = Vault.with("com/noleme/vault/parser/tag/composite.yml", defs -> {
-            defs.services().set(new ServiceValue<>("my_component", component));
-            defs.tags().register("composite_service_components", "my_component");
-        });
+        var vault = Vault.with(
+            "com/noleme/vault/parser/tag/composite.yml",
+            adjuster()
+                .services(services -> services.set(new ServiceValue<>("my_component", component)))
+                .tags(tags -> tags.register("composite_service_components", "my_component"))
+                .build()
+        );
 
         List<ComponentService> tagged = vault.instance(List.class, "composite_service_components");
 
@@ -57,9 +67,11 @@ public class AdjusterTest
         Definitions defA = parser.extract("com/noleme/vault/parser/simple.json");
         Assertions.assertEquals("SomeString", ((ServiceProvider)defA.services().get("provider.string")).getMethodArgs()[0]);
 
-        Definitions defB = parser.extract("com/noleme/vault/parser/simple.json", new Definitions(), defs -> {
-            defs.variables().set("provider.string.base_value", string);
-        });
+        Definitions defB = parser.extract(
+            "com/noleme/vault/parser/simple.json",
+            new Definitions(),
+            variables(vars -> vars.set("provider.string.base_value", string))
+        );
         Assertions.assertEquals(string, ((ServiceProvider)defB.services().get("provider.string")).getMethodArgs()[0]);
     }
 
@@ -72,10 +84,44 @@ public class AdjusterTest
         Definitions defA = parser.extract("com/noleme/vault/parser/simple.json");
         Assertions.assertEquals("SomeString", ((ServiceProvider)defA.services().get("provider.string")).getMethodArgs()[0]);
 
-        Definitions defB = parser.extract("com/noleme/vault/parser/simple.json", new Definitions(), defs -> {
-            defs.variables().set("provider.string.value", string);
-        });
+        Definitions defB = parser.extract(
+            "com/noleme/vault/parser/simple.json",
+            new Definitions(),
+            variables(vars -> vars.set("provider.string.value", string))
+        );
         Assertions.assertEquals(string, ((ServiceProvider)defB.services().get("provider.string")).getMethodArgs()[0]);
+    }
+
+    @Test
+    void testOverrideService()
+    {
+        BooleanProvider vanilla = Assertions.assertDoesNotThrow(() -> Vault.with(
+            "com/noleme/vault/parser/service/overridable.yml"
+        ).instance(BooleanProvider.class));
+
+        Assertions.assertEquals(false, vanilla.provide());
+
+        BooleanProvider overridden = Assertions.assertDoesNotThrow(() -> Vault.with(
+            "com/noleme/vault/parser/service/overridable.yml",
+            services(defs -> defs.set(new ServiceValue<>("provider.boolean", new BooleanProvider(true))))
+        ).instance(BooleanProvider.class));
+
+        Assertions.assertEquals(true, overridden.provide());
+    }
+
+    @Test
+    void testCompleteService()
+    {
+        Assertions.assertThrows(VaultInjectionException.class, () -> Vault.with(
+            "com/noleme/vault/parser/service/completeable.yml"
+        ));
+
+        BooleanProvider overridden = Assertions.assertDoesNotThrow(() -> Vault.with(
+            "com/noleme/vault/parser/service/completeable.yml",
+            services(defs -> defs.set(new ServiceValue<>("provider.boolean.base", new BooleanProvider(true))))
+        ).instance(BooleanProvider.class));
+
+        Assertions.assertEquals(true, overridden.provide());
     }
 
     public static class AdjustedService {}

--- a/src/test/java/com/noleme/vault/scope/ScopeTest.java
+++ b/src/test/java/com/noleme/vault/scope/ScopeTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
  * @author Pierre LECERF (pierre@noleme.com)
  * Created on 12/05/2021
  */
+@SuppressWarnings("resource")
 public class ScopeTest
 {
     private static final VaultFactory factory = new VaultFactory();
@@ -20,110 +21,96 @@ public class ScopeTest
     @Test
     void basicScope_shouldBuild()
     {
-        Assertions.assertDoesNotThrow(() -> {
-            var cellar = factory.populate(new Cellar(), "com/noleme/vault/parser/scope/scopes.basic.yml");
+        Cellar cellar = Assertions.assertDoesNotThrow(() -> factory.populate(new Cellar(), "com/noleme/vault/parser/scope/scopes.basic.yml"));
 
-            var service = cellar.getService("basic_service", BaseService.class);
-            Assertions.assertEquals("base_name:generic_string", service.create());
+        var service = cellar.getService("basic_service", BaseService.class);
+        Assertions.assertEquals("base_name:generic_string", service.create());
 
-            var provider = cellar.getService("basic_provider", IntegerProvider.class);
-            Assertions.assertEquals(123, provider.provide());
-        });
+        var provider = cellar.getService("basic_provider", IntegerProvider.class);
+        Assertions.assertEquals(123, provider.provide());
     }
 
     @Test
     void variableScope_shouldBuild()
     {
-        Assertions.assertDoesNotThrow(() -> {
-            var cellar = factory.populate(new Cellar(), "com/noleme/vault/parser/scope/scopes.variables.yml");
+        Cellar cellar = Assertions.assertDoesNotThrow(() -> factory.populate(new Cellar(), "com/noleme/vault/parser/scope/scopes.variables.yml"));
 
-            var service = cellar.getService("variable_service", BaseService.class);
-            Assertions.assertEquals("variable_name:generic_string", service.create());
+        var service = cellar.getService("variable_service", BaseService.class);
+        Assertions.assertEquals("variable_name:generic_string", service.create());
 
-            var provider = cellar.getService("variable_provider", IntegerProvider.class);
-            Assertions.assertEquals(567, provider.provide());
-        });
+        var provider = cellar.getService("variable_provider", IntegerProvider.class);
+        Assertions.assertEquals(567, provider.provide());
     }
 
     @Test
     void aliasScope_shouldBuild()
     {
-        Assertions.assertDoesNotThrow(() -> {
-            var cellar = factory.populate(new Cellar(), "com/noleme/vault/parser/scope/scopes.aliases.yml");
+        Cellar cellar = Assertions.assertDoesNotThrow(() -> factory.populate(new Cellar(), "com/noleme/vault/parser/scope/scopes.aliases.yml"));
 
-            var service = cellar.getService("alias_service", BaseService.class);
-            Assertions.assertEquals("base_name:alias_string", service.create());
+        var service = cellar.getService("alias_service", BaseService.class);
+        Assertions.assertEquals("base_name:alias_string", service.create());
 
-            var provider = cellar.getService("alias_provider", IntegerProvider.class);
-            Assertions.assertEquals(123, provider.provide());
-        });
+        var provider = cellar.getService("alias_provider", IntegerProvider.class);
+        Assertions.assertEquals(123, provider.provide());
     }
 
     @Test
     void scope_shouldNotConflict()
     {
-        Assertions.assertDoesNotThrow(() -> {
-            var cellar = factory.populate(new Cellar(), "com/noleme/vault/parser/scope/scopes.noconflict.yml");
+        Cellar cellar = Assertions.assertDoesNotThrow(() -> factory.populate(new Cellar(), "com/noleme/vault/parser/scope/scopes.noconflict.yml"));
 
-            var service = cellar.getService("noconflict_service", BaseService.class);
-            Assertions.assertEquals("noconflict_name:noconflict_string", service.create());
+        var service = cellar.getService("noconflict_service", BaseService.class);
+        Assertions.assertEquals("noconflict_name:noconflict_string", service.create());
 
-            var provider = cellar.getService("noconflict_provider", IntegerProvider.class);
-            Assertions.assertEquals(567, provider.provide());
+        var provider = cellar.getService("noconflict_provider", IntegerProvider.class);
+        Assertions.assertEquals(567, provider.provide());
 
-            var localService = cellar.getService("base_service", BaseService.class);
-            Assertions.assertEquals("some_name:some_string", localService.create());
+        var localService = cellar.getService("base_service", BaseService.class);
+        Assertions.assertEquals("some_name:some_string", localService.create());
 
-            var localProvider = cellar.getService("base_provider", IntegerProvider.class);
-            Assertions.assertEquals(234, localProvider.provide());
-        });
+        var localProvider = cellar.getService("base_provider", IntegerProvider.class);
+        Assertions.assertEquals(234, localProvider.provide());
     }
 
     @Test
     void tags_shouldAggregate()
     {
-        Assertions.assertDoesNotThrow(() -> {
-            var cellar = factory.populate(new Cellar(), "com/noleme/vault/parser/scope/scopes.tagged.yml");
+        Cellar cellar = Assertions.assertDoesNotThrow(() -> factory.populate(new Cellar(), "com/noleme/vault/parser/scope/scopes.tagged.yml"));
 
-            var composite = cellar.getService("composite_service", CompositeService.class);
+        var composite = cellar.getService("composite_service", CompositeService.class);
 
-            Assertions.assertEquals(3, composite.size());
-            Assertions.assertTrue(composite.contains("a"));
-            Assertions.assertTrue(composite.contains("b"));
-            Assertions.assertTrue(composite.contains("local"));
-        });
+        Assertions.assertEquals(3, composite.size());
+        Assertions.assertTrue(composite.contains("a"));
+        Assertions.assertTrue(composite.contains("b"));
+        Assertions.assertTrue(composite.contains("local"));
     }
 
     @Test
     void invocations_shouldBePassedOn()
     {
-        Assertions.assertDoesNotThrow(() -> {
-            var cellar = factory.populate(new Cellar(), "com/noleme/vault/parser/scope/scopes.invocations.yml");
+        var cellar = Assertions.assertDoesNotThrow(() -> factory.populate(new Cellar(), "com/noleme/vault/parser/scope/scopes.invocations.yml"));
 
-            var serviceA = cellar.getService("stateful_a", StatefulService.class);
-            Assertions.assertEquals(1, serviceA.getCallCount());
-            Assertions.assertEquals("default_value", serviceA.getValue());
+        var serviceA = cellar.getService("stateful_a", StatefulService.class);
+        Assertions.assertEquals(1, serviceA.getCallCount());
+        Assertions.assertEquals("default_value", serviceA.getValue());
 
-            var serviceB = cellar.getService("stateful_b", StatefulService.class);
-            Assertions.assertEquals(2, serviceB.getCallCount());
-            Assertions.assertEquals("custom_value", serviceB.getValue());
-        });
+        var serviceB = cellar.getService("stateful_b", StatefulService.class);
+        Assertions.assertEquals(2, serviceB.getCallCount());
+        Assertions.assertEquals("custom_value", serviceB.getValue());
     }
 
     @Test
     void multipleScopes_shouldBuild()
     {
-        Assertions.assertDoesNotThrow(() -> {
-            var cellar = factory.populate(new Cellar(), "com/noleme/vault/parser/scope/scopes.application.yml");
+        var cellar = Assertions.assertDoesNotThrow(() -> factory.populate(new Cellar(), "com/noleme/vault/parser/scope/scopes.application.yml"));
 
-            var serviceA = cellar.getService("my_service.a", BaseService.class);
-            Assertions.assertEquals("a_name:generic_string", serviceA.create());
+        var serviceA = cellar.getService("my_service.a", BaseService.class);
+        Assertions.assertEquals("a_name:generic_string", serviceA.create());
 
-            var serviceB = cellar.getService("my_service.b", BaseService.class);
-            Assertions.assertEquals("b_name:my_string", serviceB.create());
+        var serviceB = cellar.getService("my_service.b", BaseService.class);
+        Assertions.assertEquals("b_name:my_string", serviceB.create());
 
-            var serviceC = cellar.getService("my_service.c", BaseService.class);
-            Assertions.assertEquals("c_name:other_string", serviceC.create());
-        });
+        var serviceC = cellar.getService("my_service.c", BaseService.class);
+        Assertions.assertEquals("c_name:other_string", serviceC.create());
     }
 }

--- a/src/test/java/com/noleme/vault/tag/CompositeTest.java
+++ b/src/test/java/com/noleme/vault/tag/CompositeTest.java
@@ -31,67 +31,63 @@ public class CompositeTest
     @Test
     void compositeTest__builds()
     {
-        Assertions.assertDoesNotThrow(() -> {
-            var definitions = factory.parser().extractOrigin(List.of(
+        Cellar cellar = Assertions.assertDoesNotThrow(() -> {
+            Definitions definitions = factory.parser().extractOrigin(List.of(
                 "com/noleme/vault/parser/tag/composite.yml",
                 "com/noleme/vault/parser/tag/component.yml"
             ), new Definitions());
 
-            var cellar = factory.populate(new Cellar(), definitions);
-
-            var composite = cellar.getService("composite_service", CompositeService.class);
-            Assertions.assertTrue(composite.contains("string_a"));
-            Assertions.assertTrue(composite.contains("string_b"));
-            Assertions.assertTrue(composite.contains("string_c"));
-            Assertions.assertEquals(4, composite.size());
-
-            var compositeAlt = cellar.getService("composite_service.alt", CompositeService.class);
-            Assertions.assertFalse(compositeAlt.contains("string_a"));
-            Assertions.assertTrue(compositeAlt.contains("string_b"));
-            Assertions.assertTrue(compositeAlt.contains("string_c"));
-            Assertions.assertEquals(2, compositeAlt.size());
+            return factory.populate(new Cellar(), definitions);
         });
+
+        var composite = cellar.getService("composite_service", CompositeService.class);
+
+        Assertions.assertTrue(composite.contains("string_a"));
+        Assertions.assertTrue(composite.contains("string_b"));
+        Assertions.assertTrue(composite.contains("string_c"));
+        Assertions.assertEquals(4, composite.size());
+
+        var compositeAlt = cellar.getService("composite_service.alt", CompositeService.class);
+
+        Assertions.assertFalse(compositeAlt.contains("string_a"));
+        Assertions.assertTrue(compositeAlt.contains("string_b"));
+        Assertions.assertTrue(compositeAlt.contains("string_c"));
+        Assertions.assertEquals(2, compositeAlt.size());
     }
 
     @Test
     void compositeTest__does_not_build()
     {
-        Assertions.assertThrows(VaultInjectionException.class, () -> {
-            var definitions = factory.parser().extractOrigin(List.of(
-                "com/noleme/vault/parser/tag/composite_without_declaration.yml",
-                "com/noleme/vault/parser/tag/component.yml"
-            ), new Definitions());
+        Definitions definitions = Assertions.assertDoesNotThrow(() -> factory.parser().extractOrigin(List.of(
+            "com/noleme/vault/parser/tag/composite_without_declaration.yml",
+            "com/noleme/vault/parser/tag/component.yml"
+        ), new Definitions()));
 
-            factory.populate(new Cellar(), definitions);
-        });
+        Assertions.assertThrows(VaultInjectionException.class, () -> factory.populate(new Cellar(), definitions));
     }
 
     @Test
     void emptyCompositeTest__builds()
     {
-        Assertions.assertDoesNotThrow(() -> {
-            var cellar = factory.populate(new Cellar(), "com/noleme/vault/parser/tag/composite.yml");
+        Cellar cellar = Assertions.assertDoesNotThrow(() -> factory.populate(new Cellar(), "com/noleme/vault/parser/tag/composite.yml"));
 
-            var composite = cellar.getService("composite_service", CompositeService.class);
-            Assertions.assertEquals(0, composite.size());
-        });
+        var composite = cellar.getService("composite_service", CompositeService.class);
+        Assertions.assertEquals(0, composite.size());
     }
 
     @Test
     void compositeTest__conflictsWithService()
     {
-        Assertions.assertDoesNotThrow(() -> {
-            var cellar = factory.populate(new Cellar(), "com/noleme/vault/parser/tag/conflict_with_service.yml");
+        Cellar cellar = Assertions.assertDoesNotThrow(() -> factory.populate(new Cellar(), "com/noleme/vault/parser/tag/conflict_with_service.yml"));
 
-            var notComposite = cellar.getService("composite_service_components");
-            Assertions.assertTrue(notComposite instanceof StringProvider);
-        });
+        var notComposite = cellar.getService("composite_service_components");
+        Assertions.assertTrue(notComposite instanceof StringProvider);
     }
 
     @Test
     void customConfig__builds()
     {
-        Assertions.assertDoesNotThrow(() -> {
+        Cellar cellar = Assertions.assertDoesNotThrow(() -> {
             var parser = new VaultCompositeParser().register(new CustomModule());
             var factory = new VaultFactory(parser);
 
@@ -100,12 +96,12 @@ public class CompositeTest
                 "com/noleme/vault/parser/tag/component.yml"
             ), new Definitions());
 
-            var cellar = factory.populate(new Cellar(), definitions);
-
-            var composite = cellar.getService("my_custom_composite", CustomComposite.class);
-            Assertions.assertEquals(3, composite.size());
-            Assertions.assertEquals(7, composite.weight());
+            return factory.populate(new Cellar(), definitions);
         });
+
+        var composite = cellar.getService("my_custom_composite", CustomComposite.class);
+        Assertions.assertEquals(3, composite.size());
+        Assertions.assertEquals(7, composite.weight());
     }
 
     public static class CustomModule extends GenericModule<CustomConfig>

--- a/src/test/resources/com/noleme/vault/parser/service/completeable.yml
+++ b/src/test/resources/com/noleme/vault/parser/service/completeable.yml
@@ -1,0 +1,6 @@
+services:
+    provider.boolean:
+        class: "com.noleme.vault.service.ServiceProvider"
+        method: "provide"
+        arguments:
+            - "@provider.boolean.base"

--- a/src/test/resources/com/noleme/vault/parser/service/overridable.yml
+++ b/src/test/resources/com/noleme/vault/parser/service/overridable.yml
@@ -1,0 +1,5 @@
+services:
+    provider.boolean:
+        class: "com.noleme.vault.service.BooleanProvider"
+        constructor:
+            - false


### PR DESCRIPTION
Breaking change

Major change to the `VaultAdjuster` feature : it is now implemented as separate contracts, one for each element of the `Definitions` container.

The composite parser now runs each adjuster after their corresponding sequence (eg. the variables adjuster is run after we process the variable definitions, the services adjuster is run after we process the services definitions, etc.) so we can now properly handle both dynamic completion and override of definitions.